### PR TITLE
Add Code Climate checks

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,10 @@
+version: "2"
+plugins:
+  shellcheck:
+    enabled: true
+  bandit:
+    enabled: true
+  markdownlint:
+    enabled: true
+  pep8:
+    enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
 - n/a
 
 ## 1.0.0 - 2019-02-07
+
 ### Added
+
 - Initial release

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A Python client for the [Akamai Fast Purge API](https://developer.akamai.com/api
 
 [![Build Status](https://travis-ci.org/release-engineering/python-fastpurge.svg?branch=master)](https://travis-ci.org/release-engineering/python-fastpurge)
 [![Coverage Status](https://coveralls.io/repos/github/release-engineering/python-fastpurge/badge.svg?branch=master)](https://coveralls.io/github/release-engineering/python-fastpurge?branch=master)
+[![Maintainability](https://api.codeclimate.com/v1/badges/2a5d60f6ddb557d88055/maintainability)](https://codeclimate.com/github/release-engineering/python-fastpurge/maintainability)
 
 - [Source](https://github.com/release-engineering/python-fastpurge)
 - [Documentation](https://release-engineering.github.io/python-fastpurge/)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Install the `fastpurge` package from PyPI.
 pip install fastpurge
 ```
 
-
 Usage Example
 -------------
 
@@ -48,7 +47,6 @@ purged = client.purge_by_url(['https://example.com/resource1', 'https://example.
 result = purged.result()
 print("Purge completed:", result)
 ```
-
 
 License
 -------

--- a/scripts/push-docs
+++ b/scripts/push-docs
@@ -2,7 +2,7 @@
 set -e
 
 enabled(){
-  if [ "$TRAVIS_BRANCH" != "master" ] || [ $TRAVIS_PULL_REQUEST != "false" ]; then
+  if [ "$TRAVIS_BRANCH" != "master" ] || [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
     return 1
   fi
 }

--- a/tox.ini
+++ b/tox.ini
@@ -47,3 +47,6 @@ commands=
 
 [flake8]
 max-line-length = 100
+
+[pep8]
+max-line-length = 100


### PR DESCRIPTION
Add some checks from Code Climate checker. This is the checks that are added and their explanation:

* `shellcheck` - checks shell scripts
* `bandit` - security checker
* `markdownlint` - checks markdown files to be written by guidelines
* `pep8` - checks python pep8 style
