### PR TITLE
Add more-executors >= 1.19.1 requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-more-executors
+more-executors>=1.19.1
 six
 monotonic
 edgegrid-python

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     ],
     install_requires=[
         'requests',
-        'more-executors',
+        'more-executors>=1.19.1',
         'six',
         'monotonic',
         'edgegrid-python',


### PR DESCRIPTION
The more-executors futures package used in python-fastpurge was introduced in version 1.19.1. Add the requirement to setup.py and requirements.txt.