### PR TITLE
Avoid coveralls 1.6.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ passenv = TRAVIS TRAVIS_*
 deps=
 	-rtest-requirements.txt
 	pytest-cov
-	coveralls
+	coveralls<1.6.0
 usedevelop=true
 commands=
 	pytest --cov=fastpurge {posargs}


### PR DESCRIPTION
This version of coveralls, just released, breaks upload of coverage
reports for our pull requests. Not sure why yet, but let's stick
to an older version until it's sorted out.