### PR TITLE
Fixed wrong host in auth example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- n/a
+### Fixed
+
+- Fixed a wrong example in documentation
 
 ## 1.0.1 - 2019-02-20
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,7 +59,7 @@ explicitly, as in example:
     from fastpurge import FastPurgeClient
     client = FastPurgeClient(auth={
         # The entries from ~/.edgerc can be supplied directly here
-        "host": "akaa-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx.luna.akamaiapis.net",
+        "host": "akaa-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx.purge.akamaiapis.net",
         "client_token": "akab-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx",
         "client_secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
         "access_token": "akab-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx",


### PR DESCRIPTION
Akamai docs for edgerc give an example host matching: *.luna.akamaiapis.net

In fact, there are different subdomains for different APIs,
and our users are finding that a luna.akamaiapis.net host doesn't work here.

Valid credentials for the fast purge API appear to use a host
under *.purge.akamaiapis.net subdomain, so make the example accurate.