### PR TITLE
refactor: give executor a name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- n/a
+### Changed
+
+- Executors are now named for improved metrics/debuggability.
 
 ## 1.0.2 - 2019-03-20
 

--- a/fastpurge/_client.py
+++ b/fastpurge/_client.py
@@ -134,7 +134,7 @@ class FastPurgeClient(object):
             with self.__lock:
                 if self.___executor is None:
                     self.___executor = Executors.\
-                        sync().\
+                        sync(name="fastpurge").\
                         with_poll(self.__poll_purges).\
                         with_throttle(count=self.MAX_REQUESTS).\
                         with_retry().\

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-more-executors>=1.19.1
+more-executors>=2.7.0
 six
 monotonic
 edgegrid-python


### PR DESCRIPTION
Naming our executor is a good idea because:

- the name will be reused in any created threads, so we can
  figure out which code created which thread

- the name will appear in prometheus metrics