### PR TITLE
Add Bandit scanning to pipeline [RHELDST-12100]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ matrix:
     env: TOX_ENV=cov-travis DEPLOY=1
   - python: "3.5"
     env: TOX_ENV=docs
+  - python: "3.8"
+    env: TOX_ENV=py3-bandit-exitzero
+  - python: "3.8"
+    env: TOX_ENV=py3-bandit
 script: tox -e $TOX_ENV
 after_success:
 - test $TOX_ENV = docs && scripts/push-docs

--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,14 @@ use_develop=true
 commands=
 	sphinx-build -M html docs docs/_build
 
+[testenv:py3-bandit-exitzero]
+deps = bandit
+commands = bandit -r . -l --exclude './.tox' --exit-zero
+
+[testenv:py3-bandit]
+deps = bandit
+commands = bandit -r . -ll --exclude './.tox'
+
 [flake8]
 max-line-length = 100
 


### PR DESCRIPTION
To enable SAST scanning on this repository, Bandit has been added into
the tox.ini and .travis.yml files.  Two tests are executed in the
pipeline: py3-bandit-exitzero and py3-bandit.

The first scan lists all findings of low severity or higher and always
passes due to the "exit-zero" option.  This will allow tracking of low
severity findings without stopping code from being merged in.

The second scan lists all findings of medium severity or higher and will
fail the pipeline if any issues have been introduced.

To track the overall progress of Bandit enablement on Pub open-source
libraries, see Jira [RHELDST-9236].