### PR TITLE
Use time.monotonic on py3.3+

### DIFF
--- a/fastpurge/_client.py
+++ b/fastpurge/_client.py
@@ -7,12 +7,16 @@ from threading import local, Lock
 
 import requests
 
+try:
+    from time import monotonic
+except ImportError:  # pragma: no cover
+    from monotonic import monotonic
+
 from six import string_types
 from six.moves.urllib.parse import urljoin
 
 from akamai.edgegrid import EdgeGridAuth
 from akamai.edgegrid.edgerc import EdgeRc
-from monotonic import monotonic
 from more_executors import Executors
 from more_executors.futures import f_sequence
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
 more-executors>=2.7.0
 six
-monotonic
+monotonic; python_version < '3.3'
 edgegrid-python

--- a/tests/test_purge.py
+++ b/tests/test_purge.py
@@ -2,7 +2,10 @@ import pytest
 import requests_mock
 import mock
 
-from monotonic import monotonic
+try:
+    from time import monotonic
+except ImportError:
+    from monotonic import monotonic
 
 from fastpurge import FastPurgeClient, FastPurgeError
 


### PR DESCRIPTION
On Python 3.3 or newer, `monotonic` module aliases `time.monotonic` from the standard library. On older versions, it will fall back to an equivalent platform specific implementation provided by the `monotonic` module.
Attempting to import `time.monotonic` right off the bat removes the need for additional dependency on modern python installations.