### PR TITLE
Fix tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py27,py39,py310,py311,static,docs
 [testenv]
 deps=-rtest-requirements.txt
 commands=pytest -v {posargs}
-whitelist_externals=sh
+allowlist_externals=sh
 
 [testenv:static]
 deps=


### PR DESCRIPTION
Option whitelist_externals was removed in newer versions of tox, using allowlist_externals instead.