### PR TITLE
Drop Python2 support

### DIFF
--- a/fastpurge/_client.py
+++ b/fastpurge/_client.py
@@ -7,13 +7,9 @@ from threading import local, Lock
 
 import requests
 
-try:
-    from time import monotonic
-except ImportError:  # pragma: no cover
-    from monotonic import monotonic
+from time import monotonic
 
-from six import string_types
-from six.moves.urllib.parse import urljoin
+from urllib.parse import urljoin
 
 from akamai.edgegrid import EdgeGridAuth
 from akamai.edgegrid.edgerc import EdgeRc
@@ -345,7 +341,7 @@ def get_auth_dict(value):
     if value is None:
         value = os.path.expanduser('~/.edgerc')
 
-    if not isinstance(value, string_types):
+    if not isinstance(value, str):
         raise TypeError("Invalid 'auth' argument")
 
     if not os.path.exists(value):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 requests
 more-executors>=2.7.0
-six
-monotonic; python_version < '3.3'
 edgegrid-python

--- a/setup.py
+++ b/setup.py
@@ -32,14 +32,12 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     install_requires=get_requirements(),
-    python_requires='>=2.6',
+    python_requires='>=3.6',
     project_urls={
         'Documentation':
             'https://release-engineering.github.io/python-fastpurge/',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py39,py310,py311,static,docs
+envlist = py39,py310,py311,static,docs
 
 [testenv]
 deps=-rtest-requirements.txt


### PR DESCRIPTION
After Supercharge Pub 3 was delivered, Python 2 support is no longer required in it's dependencies as well. Dropping Python 2 will make the repos easier to maintain and will speed up Tox and Github Actions since some steps can be removed.