### PR TITLE
Pin bandit version

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 pytest
 requests-mock
 mock
+bandit==1.7.5;python_version > '3'

--- a/tox.ini
+++ b/tox.ini
@@ -35,11 +35,11 @@ commands=
 	sphinx-build -M html docs docs/_build
 
 [testenv:py3-bandit-exitzero]
-deps = bandit
+deps = -rtest-requirements.txt
 commands = bandit -r . -l --exclude './.tox' --exit-zero
 
 [testenv:py3-bandit]
-deps = bandit
+deps = -rtest-requirements.txt
 commands = bandit -r . -ll --exclude './.tox'
 
 [flake8]


### PR DESCRIPTION
We pin the version of Bandit SAST tool to make the CI tests more predictable. If we used the latest version available without pinning it, the CI tests could start failing on new Bandit version without any changes in our codebase.

We pin the Bandit version by adding version requirement to test-requirements.txt