### PR TITLE
Retire python 2 support [RHELDST-15344]

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -3,20 +3,6 @@ name: Tox tests
 on: [push, pull_request]
 
 jobs:
-  py27:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install RPM
-        run: sudo apt-get install -y rpm libkrb5-dev
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '2.7'
-      - name: Install Tox
-        run: pip install tox
-      - name: Run Tox
-        run: tox -e py27
   py39:
     runs-on: ubuntu-latest
     steps:

--- a/setup.py
+++ b/setup.py
@@ -32,14 +32,11 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     install_requires=get_requirements(),
-    python_requires='>=2.6',
+    python_requires='>=3.6',
     project_urls={
         'Documentation':
             'https://release-engineering.github.io/python-fastpurge/',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py39,py310,py311,static,docs
+envlist = py39,py310,py311,static,docs
 
 [testenv]
 deps=-rtest-requirements.txt


### PR DESCRIPTION
1.Remove python2-specific entries in 'classifiers'. 2.Specify minimal python version to 3.6.