### PR TITLE
Add clearer retry logic with logging [RHELDST-9679]

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@ pytest
 requests-mock
 mock
 bandit==1.7.5;python_version > '3'
+responses


### PR DESCRIPTION
Poor retry logic in this library has made some pub tasks fail. The logs are also unclear as to whether retries are occurring or not. This change extends the urllib3 retry logic to include logging to resolve both issues. It also introduces new envvars to make the retry periods configurable. The default backoff settings retry the request 10 times over a 5 minute period.


I have also included the `responses` library for testing the retry logic. The mock_requests library appeared to not be able to support it, while responses had very clear support. 