### PR TITLE
Remove redundant future retry [RHELDST-9679]

### DIFF
--- a/fastpurge/_client.py
+++ b/fastpurge/_client.py
@@ -173,7 +173,6 @@ class FastPurgeClient(object):
                         sync(name="fastpurge").\
                         with_poll(self.__poll_purges).\
                         with_throttle(count=self.MAX_REQUESTS).\
-                        with_retry().\
                         with_cancel_on_shutdown()
         return self.___executor
 


### PR DESCRIPTION
Originally, the fast purge client would retry failed futures. Now with the HTTP retries it doesn't make sense to have both. The interaction between the two causes failing purges to run much longer than the desired 5 minutes.

This change removes the Future retry in favour of the urllib3 retry.