### PR TITLE
Update codecov-action to v4

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -74,15 +74,16 @@ jobs:
       - name: Run Tox
         run: tox -e cov
 
-      # Codcov Action required installing pytest-cov as it needs coverage.
+      # Codecov Action required installing pytest-cov as it needs coverage.
       # The coverage library installed within tox is in virt-env and not 
       # accessible to Codecov.
       - name: Install pytest cov
         run: pip install pytest-cov
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true
   docs:

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps=
 	pytest-cov
 usedevelop=true
 commands=
-	pytest --cov-report=html --cov=fastpurge {posargs}
+	pytest --cov-report=html --cov-report=xml --cov=fastpurge {posargs}
 
 [testenv:docs]
 deps=


### PR DESCRIPTION
In V4, PRs made from forks to the upstream public repos will support
tokenless uploading.